### PR TITLE
yocs_velocity_smootherを使用したときに発生するエラーに対応するための修正

### DIFF
--- a/launch/logicool.launch
+++ b/launch/logicool.launch
@@ -2,7 +2,7 @@
 <launch>
   <arg name="dev" default="/dev/input/js0" />
   <node pkg="joy" name="joy_node" type="joy_node" required="true">
-    <param name="autorepeat_rate" value="3" />
+    <param name="autorepeat_rate" value="20" />
     <param name="dev" type="string" value="$(arg dev)" />
   </node>
 

--- a/scripts/logicool_cmd_vel.py
+++ b/scripts/logicool_cmd_vel.py
@@ -13,33 +13,37 @@ class JoyTwist(object):
         self._smooth_twist_pub = rospy.Publisher('/raw_cmd_vel', Twist, queue_size=1)
         
         self.smooth_flag = False
-        #self.level = 1
+        self.level = 1
     
-    #def limitter(self, lvl):
-        #if lvl <= 0:
-            #return 1
-        #if lvl >= 6:
-            #return 5
-        #return lvl
+    def limitter(self, lvl):
+        if lvl <= 0:
+            return 1
+        if lvl >= 6:
+            return 5
+        return lvl
 
     def joy_callback(self, joy_msg):
-        #if joy_msg.buttons[7] == 1:
-            #self.level += 1
-        #if joy_msg.buttons[6] == 1:
-            #self.level -= 1
-        #self.level = self.limitter(self.level)
+        if joy_msg.buttons[7] == 1:
+            self.level += 1
+        if joy_msg.buttons[6] == 1:
+            self.level -= 1
+        self.level = self.limitter(self.level)
 
         twist = Twist()
         if joy_msg.buttons[0] == 1:
+            # uncomment the following two lines to use speed up function
             #twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
             #twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
+            # uncomment the following two lines to use speed up function
             twist.linear.x = joy_msg.axes[1] * 0.4
             twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * 15
             self._twist_pub.publish(twist)
             self.smooth_flag = False
         elif joy_msg.buttons[2] == 1:
+            # uncomment the following two lines to use speed up function
             #twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
             #twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
+            # uncomment the following two lines to use speed up function
             twist.linear.x = joy_msg.axes[1] * 0.4
             twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * 15
             self._smooth_twist_pub.publish(twist)
@@ -52,8 +56,8 @@ class JoyTwist(object):
             elif not self.smooth_flag:
                 self._twist_pub.publish(twist)
 
-        #if joy_msg.axes[1] == joy_msg.axes[0] == 0:
-            #self.level -= 1
+        if joy_msg.axes[1] == joy_msg.axes[0] == 0:
+            self.level -= 1
 
 if __name__ == '__main__':
     rospy.wait_for_service('/motor_on')

--- a/scripts/logicool_cmd_vel.py
+++ b/scripts/logicool_cmd_vel.py
@@ -11,40 +11,52 @@ class JoyTwist(object):
         self._joy_sub = rospy.Subscriber('/joy', Joy, self.joy_callback, queue_size=1)
         self._twist_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
         self._smooth_twist_pub = rospy.Publisher('/raw_cmd_vel', Twist, queue_size=1)
-
+        
+        self.smooth_flag = False
+    '''
         self.level = 1
-
+    
     def limitter(self, lvl):
         if lvl <= 0:
             return 1
         if lvl >= 6:
             return 5
         return lvl
-
+    '''
     def joy_callback(self, joy_msg):
+        '''
         if joy_msg.buttons[7] == 1:
             self.level += 1
         if joy_msg.buttons[6] == 1:
             self.level -= 1
         self.level = self.limitter(self.level)
-
+        '''
         twist = Twist()
         if joy_msg.buttons[0] == 1:
-            twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
-            twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
+            #twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
+            #twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
+            twist.linear.x = joy_msg.axes[1] * 0.4
+            twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * 15
             self._twist_pub.publish(twist)
+            self.smooth_flag = False
         elif joy_msg.buttons[2] == 1:
-            twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
-            twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
+            #twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
+            #twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
+            twist.linear.x = joy_msg.axes[1] * 0.4
+            twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * 15
             self._smooth_twist_pub.publish(twist)
+            self.smooth_flag = True;
         else:
             twist.linear.x = 0
             twist.angular.z = 0
-            self._twist_pub.publish(twist)
-
+            if self.smooth_flag:
+                self._smooth_twist_pub.publish(twist)
+            elif not self.smooth_flag:
+                self._twist_pub.publish(twist)
+        '''
         if joy_msg.axes[1] == joy_msg.axes[0] == 0:
             self.level -= 1
-
+        '''
 
 if __name__ == '__main__':
     rospy.wait_for_service('/motor_on')

--- a/scripts/logicool_cmd_vel.py
+++ b/scripts/logicool_cmd_vel.py
@@ -14,7 +14,6 @@ class JoyTwist(object):
         
         self.smooth_flag = False
         self.level = 1
-    
     def limitter(self, lvl):
         if lvl <= 0:
             return 1

--- a/scripts/logicool_cmd_vel.py
+++ b/scripts/logicool_cmd_vel.py
@@ -34,7 +34,7 @@ class JoyTwist(object):
             # uncomment the following two lines to use speed up function
             #twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
             #twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
-            # uncomment the following two lines to use speed up function
+            # comment out the following two lines to use speed up function
             twist.linear.x = joy_msg.axes[1] * 0.4
             twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * 15
             self._twist_pub.publish(twist)

--- a/scripts/logicool_cmd_vel.py
+++ b/scripts/logicool_cmd_vel.py
@@ -13,24 +13,22 @@ class JoyTwist(object):
         self._smooth_twist_pub = rospy.Publisher('/raw_cmd_vel', Twist, queue_size=1)
         
         self.smooth_flag = False
-    '''
-        self.level = 1
+        #self.level = 1
     
-    def limitter(self, lvl):
-        if lvl <= 0:
-            return 1
-        if lvl >= 6:
-            return 5
-        return lvl
-    '''
+    #def limitter(self, lvl):
+        #if lvl <= 0:
+            #return 1
+        #if lvl >= 6:
+            #return 5
+        #return lvl
+
     def joy_callback(self, joy_msg):
-        '''
-        if joy_msg.buttons[7] == 1:
-            self.level += 1
-        if joy_msg.buttons[6] == 1:
-            self.level -= 1
-        self.level = self.limitter(self.level)
-        '''
+        #if joy_msg.buttons[7] == 1:
+            #self.level += 1
+        #if joy_msg.buttons[6] == 1:
+            #self.level -= 1
+        #self.level = self.limitter(self.level)
+
         twist = Twist()
         if joy_msg.buttons[0] == 1:
             #twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
@@ -53,10 +51,9 @@ class JoyTwist(object):
                 self._smooth_twist_pub.publish(twist)
             elif not self.smooth_flag:
                 self._twist_pub.publish(twist)
-        '''
-        if joy_msg.axes[1] == joy_msg.axes[0] == 0:
-            self.level -= 1
-        '''
+
+        #if joy_msg.axes[1] == joy_msg.axes[0] == 0:
+            #self.level -= 1
 
 if __name__ == '__main__':
     rospy.wait_for_service('/motor_on')

--- a/scripts/logicool_cmd_vel.py
+++ b/scripts/logicool_cmd_vel.py
@@ -43,7 +43,7 @@ class JoyTwist(object):
             # uncomment the following two lines to use speed up function
             #twist.linear.x = joy_msg.axes[1] * 0.4 * self.level
             #twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * (self.level + 15)
-            # uncomment the following two lines to use speed up function
+            # comment out the following two lines to use speed up function
             twist.linear.x = joy_msg.axes[1] * 0.4
             twist.angular.z = joy_msg.axes[0] * 3.14 / 32 * 15
             self._smooth_twist_pub.publish(twist)


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
yocs_velocity_smootherを使用したときに発生するエラーに対応するための修正。
停止時に下記のエラーが発生すると、本来停止する予定の場所から少し進んだ位置に停止してしまう。
```
発生するエラー
Velocity Smoother : input got inactive leaving us a non-zero target velocity (0.4, -0), zeroing...[velocity_smoother]
```

* yocs_velocity_smootherを使用したときに発生するエラーに対応するための修正について

1.https://github.com/uhobeike/raspicat_gamepad_controller/blob/299b89a119b4cee1da9dda53ccc014a159ac8f22/scripts/logicool_cmd_vel.py#L50
の条件は、一度[smooth_twist_pub.publish](https://github.com/uhobeike/raspicat_gamepad_controller/blob/299b89a119b4cee1da9dda53ccc014a159ac8f22/scripts/logicool_cmd_vel.py#L45)をした場合`twist.linear.x = 0`と`twist.angular.z = 0`を`twist_pub.publish`ではなく、[smooth_twist_pub.publish](https://github.com/uhobeike/raspicat_gamepad_controller/blob/299b89a119b4cee1da9dda53ccc014a159ac8f22/scripts/logicool_cmd_vel.py#L51)で常にpublishするように変更した。

2.https://github.com/uhobeike/raspicat_gamepad_controller/blob/3ae3230a8a739cf91584c458edc435bd9999340e/launch/logicool.launch#L5
の値を20に設定した。この値の修正は、人が操作してもyocs_velocity_smoother側である程度一定の間隔で`/smooth_cmd_vel`のトピックを受け取れるように変更したものである。そうすることで、[エラー文の出力前の条件分岐](https://github.com/yujinrobot/yujin_ocs/blob/17337e5a2d0a0f3711c55e272e656eb59174d657/yocs_velocity_smoother/src/velocity_smoother_nodelet.cpp#L139)に入ることを防ぐことが出来る。


# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
```
PC
~$ roscore
```
```
raspicat
~$ roslaunch raspicat_gamepad_controller run_with_base_nodes.launch
```

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
